### PR TITLE
Only show buffering view if we're buffering and playing

### DIFF
--- a/lib/src/widgets/flick_video_buffer.dart
+++ b/lib/src/widgets/flick_video_buffer.dart
@@ -2,7 +2,7 @@ import 'package:flick_video_player/flick_video_player.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-/// Shows a widget when the video is buffering.
+/// Shows a widget when the video is buffering (and video is playing).
 class FlickVideoBuffer extends StatelessWidget {
   const FlickVideoBuffer({
     Key? key,
@@ -21,7 +21,9 @@ class FlickVideoBuffer extends StatelessWidget {
     FlickVideoManager videoManager = Provider.of<FlickVideoManager>(context);
 
     return Container(
-      child: videoManager.isBuffering ? bufferingChild : child,
+      child: (videoManager.isBuffering && videoManager.isPlaying)
+          ? bufferingChild
+          : child,
     );
   }
 }


### PR DESCRIPTION
If you initialize the video and seek to a specific position this will result in an endless spinner on Android. This is because https://github.com/flutter/flutter/issues/61004

One way to fix this is to fix `video_player`.

The other is to only show buffering feedback whenever there is actual need for that (that is whenever user wants to play video)