### PR TITLE
Update Video player and removed depreciated  setEnabledSystemUIOverlays

### DIFF
--- a/example/lib/landscape_player/landscape_player_controls.dart
+++ b/example/lib/landscape_player/landscape_player_controls.dart
@@ -130,8 +130,8 @@ class LandscapePlayerControls extends StatelessWidget {
           top: 10,
           child: GestureDetector(
             onTap: () {
-              SystemChrome.setEnabledSystemUIOverlays(SystemUiOverlay.values);
-              // SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual);
+              SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
+                  overlays: SystemUiOverlay.values);
               SystemChrome.setPreferredOrientations(
                   [DeviceOrientation.portraitUp]);
               Navigator.pop(context);

--- a/example/lib/landscape_player/landscape_player_controls.dart
+++ b/example/lib/landscape_player/landscape_player_controls.dart
@@ -130,8 +130,8 @@ class LandscapePlayerControls extends StatelessWidget {
           top: 10,
           child: GestureDetector(
             onTap: () {
-              // SystemChrome.setEnabledSystemUIOverlays(SystemUiOverlay.values);
-              SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual);
+              SystemChrome.setEnabledSystemUIOverlays(SystemUiOverlay.values);
+              // SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual);
               SystemChrome.setPreferredOrientations(
                   [DeviceOrientation.portraitUp]);
               Navigator.pop(context);

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -23,8 +23,8 @@ dependencies:
     sdk: flutter
   visibility_detector: ^0.2.0
   flick_video_player:
-    path: '../'
-  video_player: ^2.2.5
+    path: "../"
+  video_player: ^2.2.7
   provider: ^6.0.1
 
   # The following adds the Cupertino Icons font to your application.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   visibility_detector: ^0.2.0
   flick_video_player:
     path: "../"
-  video_player: ^2.2.7
+  video_player: ^2.2.10
   provider: ^6.0.1
 
   # The following adds the Cupertino Icons font to your application.

--- a/lib/src/flick_video_player.dart
+++ b/lib/src/flick_video_player.dart
@@ -165,10 +165,10 @@ class _FlickVideoPlayerState extends State<FlickVideoPlayer> {
     var aspectRatio =
         widget.flickManager.flickVideoManager!.videoPlayerValue!.aspectRatio;
     if (_isFullscreen && aspectRatio >= 1) {
-      // SystemChrome.setPreferredOrientations(
-      //     widget.preferredDeviceOrientationFullscreen);
+      SystemChrome.setPreferredOrientations(
+          widget.preferredDeviceOrientationFullscreen);
     } else {
-      // SystemChrome.setPreferredOrientations(widget.preferredDeviceOrientation);
+      SystemChrome.setPreferredOrientations(widget.preferredDeviceOrientation);
     }
   }
 

--- a/lib/src/flick_video_player.dart
+++ b/lib/src/flick_video_player.dart
@@ -165,18 +165,18 @@ class _FlickVideoPlayerState extends State<FlickVideoPlayer> {
     var aspectRatio =
         widget.flickManager.flickVideoManager!.videoPlayerValue!.aspectRatio;
     if (_isFullscreen && aspectRatio >= 1) {
-      SystemChrome.setPreferredOrientations(
-          widget.preferredDeviceOrientationFullscreen);
+      // SystemChrome.setPreferredOrientations(
+      //     widget.preferredDeviceOrientationFullscreen);
     } else {
-      SystemChrome.setPreferredOrientations(widget.preferredDeviceOrientation);
+      // SystemChrome.setPreferredOrientations(widget.preferredDeviceOrientation);
     }
   }
 
   _setSystemUIOverlays() {
     if (_isFullscreen) {
-      SystemChrome.setEnabledSystemUIOverlays(widget.systemUIOverlayFullscreen);
+      // SystemChrome.setEnabledSystemUIOverlays(widget.systemUIOverlayFullscreen);
     } else {
-      SystemChrome.setEnabledSystemUIOverlays(widget.systemUIOverlay);
+      // SystemChrome.setEnabledSystemUIOverlays(widget.systemUIOverlay);
     }
   }
 

--- a/lib/src/flick_video_player.dart
+++ b/lib/src/flick_video_player.dart
@@ -174,9 +174,11 @@ class _FlickVideoPlayerState extends State<FlickVideoPlayer> {
 
   _setSystemUIOverlays() {
     if (_isFullscreen) {
-      // SystemChrome.setEnabledSystemUIOverlays(widget.systemUIOverlayFullscreen);
+      SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
+          overlays: widget.systemUIOverlayFullscreen);
     } else {
-      // SystemChrome.setEnabledSystemUIOverlays(widget.systemUIOverlay);
+      SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
+          overlays: widget.systemUIOverlay);
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  video_player: ^2.2.7
+  video_player: ^2.2.10
   provider: ^6.0.1
   wakelock: ^0.5.6
   universal_html: ^2.0.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,9 +11,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  video_player: ^2.2.5
+  video_player: ^2.2.7
   provider: ^6.0.1
-  wakelock: ^0.5.0+3
+  wakelock: ^0.5.6
   universal_html: ^2.0.8
 
 dev_dependencies:


### PR DESCRIPTION
- Updated video_player to latest version video_player: ^2.2.10
- updated wakelock to  wakelock: ^0.5.6
- setEnabledSystemUIOverlays is deprecated and shouldn't be used. Migrate to setEnabledSystemUIMode