### PR TITLE
IOS Swipe to go back fix

### DIFF
--- a/lib/src/flick_video_player.dart
+++ b/lib/src/flick_video_player.dart
@@ -200,13 +200,12 @@ class _FlickVideoPlayerState extends State<FlickVideoPlayer> {
   @override
   Widget build(BuildContext context) {
     return WillPopScope(
-      onWillPop: () {
-        if (_overlayEntry != null) {
-          flickManager.flickControlManager!.exitFullscreen();
-          return Future.value(false);
-        }
-        return Future.value(true);
-      },
+      onWillPop: _overlayEntry != null
+          ? () {
+              flickManager.flickControlManager!.exitFullscreen();
+              return Future.value(false);
+            }
+          : null,
       child: FlickManagerBuilder(
         flickManager: flickManager,
         child: widget.flickVideoWithControls,


### PR DESCRIPTION
WillPopScope triggers when the navigator pops the screen.
But it also clashes with IOS Swipe to go back gesture. Issue: https://github.com/flutter/flutter/issues/14203

Making onWillPop solves the problem since it have no use when Video Player is not in full screen mode.