### PR TITLE
fixed loader not showing up while buffering

### DIFF
--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,7 +5,7 @@
 import FlutterMacOS
 import Foundation
 
-import path_provider_macos
+import path_provider_foundation
 import wakelock_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {

--- a/lib/src/manager/video_manager.dart
+++ b/lib/src/manager/video_manager.dart
@@ -181,10 +181,11 @@ class FlickVideoManager extends ChangeNotifier {
     // Mark video is buffering if video has not ended, has no error,
     // and position is equal to buffered duration.
     _isBuffering = !isVideoEnded &&
-        !videoPlayerValue!.hasError &&
-        videoPlayerController!.value.buffered.isNotEmpty == true &&
-        videoPlayerController!.value.position.inSeconds >=
-            videoPlayerController!.value.buffered[0].end.inSeconds;
+            !videoPlayerValue!.hasError &&
+            videoPlayerController!.value.isBuffering ||
+        (videoPlayerController!.value.buffered.isNotEmpty == true &&
+            videoPlayerController!.value.position.inSeconds >=
+                videoPlayerController!.value.buffered[0].end.inSeconds);
 
     _notify();
   }


### PR DESCRIPTION
Sometimes when the internet connection is slow, the video looks to be paused but still Flick Player doesn't indicate the reason, later found that even when value of `isBuffering` is true in the native player controller, the value of `isBuffering` from FlickControlManager is false. on making a small change in the code, the issue seems to be resolved.