### PR TITLE
conf(FlickVideoPlayer): use wakelock compatible with Flutter 3.10 and Dart 3

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -75,3 +75,17 @@ flutter:
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages
+
+# https://github.com/GeekyAnts/flick-video-player/issues/226
+# https://github.com/creativecreatorormaybenot/wakelock/pull/213
+dependency_overrides:
+  wakelock:
+    git:
+      url: https://github.com/formigas/wakelock.git
+      path: wakelock/
+      ref: main
+  wakelock_windows:
+    git:
+      url: https://github.com/formigas/wakelock.git
+      path: wakelock_windows/
+      ref: main

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   provider: ^6.0.1
   wakelock:
   universal_html: ^2.0.8
-  dio: ^4.0.6
+  dio: ^5.2.1
   path_provider: ^2.0.11
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   video_player: ^2.4.0
   provider: ^6.0.1
-  wakelock: ^0.6.0
+  wakelock:
   universal_html: ^2.0.8
   dio: ^4.0.6
   path_provider: ^2.0.11
@@ -25,3 +25,17 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+# https://github.com/GeekyAnts/flick-video-player/issues/226
+# https://github.com/creativecreatorormaybenot/wakelock/pull/213
+dependency_overrides:
+  wakelock:
+    git:
+      url: https://github.com/formigas/wakelock.git
+      path: wakelock/
+      ref: main
+  wakelock_windows:
+    git:
+      url: https://github.com/formigas/wakelock.git
+      path: wakelock_windows/
+      ref: main

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,18 @@ dependencies:
     sdk: flutter
   video_player: ^2.4.0
   provider: ^6.0.1
+# https://github.com/creativecreatorormaybenot/wakelock/pull/213
+# https://github.com/GeekyAnts/flick-video-player/issues/226
   wakelock:
+    git:
+      url: https://github.com/formigas/wakelock.git
+      path: wakelock/
+      ref: main
+  wakelock_windows:
+    git:
+      url: https://github.com/formigas/wakelock.git
+      path: wakelock_windows/
+      ref: main
   universal_html: ^2.0.8
   dio: ^5.2.1
   path_provider: ^2.0.11
@@ -26,16 +37,3 @@ dev_dependencies:
 flutter:
   uses-material-design: true
 
-# https://github.com/GeekyAnts/flick-video-player/issues/226
-# https://github.com/creativecreatorormaybenot/wakelock/pull/213
-dependency_overrides:
-  wakelock:
-    git:
-      url: https://github.com/formigas/wakelock.git
-      path: wakelock/
-      ref: main
-  wakelock_windows:
-    git:
-      url: https://github.com/formigas/wakelock.git
-      path: wakelock_windows/
-      ref: main


### PR DESCRIPTION
#226 

https://github.com/creativecreatorormaybenot/wakelock/pull/213
```yaml
dependency_overrides:
  flick_video_player:
    git:
      url: https://github.com/BesartLaci/flick-video-player.git
      ref: 226/use-wacklock-compatible-with-flutter-3-10-and-dart-3  
```