### PR TITLE
🔨 Added a fix for screen black out in web on fullscreen exit

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -70,21 +70,23 @@ class _ExamplesState extends State<Examples> {
   }
 
   Widget _buildWebView() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: <Widget>[
-        Expanded(child: WebVideoPlayer()),
-        Container(
-          child: Padding(
-            padding: const EdgeInsets.all(15.0),
-            child: Text('Flick video player',
-                style: TextStyle(
-                  color: Color.fromRGBO(100, 109, 236, 1),
-                  fontWeight: FontWeight.bold,
-                )),
-          ),
-        )
-      ],
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          WebVideoPlayer(),
+          Container(
+            child: Padding(
+              padding: const EdgeInsets.all(15.0),
+              child: Text('Flick video player',
+                  style: TextStyle(
+                    color: Color.fromRGBO(100, 109, 236, 1),
+                    fontWeight: FontWeight.bold,
+                  )),
+            ),
+          )
+        ],
+      ),
     );
   }
 

--- a/lib/src/manager/control_manager.dart
+++ b/lib/src/manager/control_manager.dart
@@ -40,15 +40,6 @@ class FlickControlManager extends ChangeNotifier {
 
   /// Exit full-screen.
   void exitFullscreen() {
-    if (kIsWeb) {
-      // trigger controllers again after exiting full screen in web
-      togglePlay();
-      _notify();
-      Future.delayed(Duration(seconds: 1), () {
-        togglePlay();
-        _notify();
-      });
-    }
     _isFullscreen = false;
     _flickManager._handleToggleFullscreen();
     _notify();


### PR DESCRIPTION
Removed overlay implementation for web and directly making the video to adjust to the screen dimensions.