### PR TITLE
Add option to pass OverlayState for showing the fullscreen player

### DIFF
--- a/lib/src/flick_video_player.dart
+++ b/lib/src/flick_video_player.dart
@@ -74,7 +74,8 @@ class FlickVideoPlayer extends StatefulWidget {
   _FlickVideoPlayerState createState() => _FlickVideoPlayerState();
 }
 
-class _FlickVideoPlayerState extends State<FlickVideoPlayer> with WidgetsBindingObserver {
+class _FlickVideoPlayerState extends State<FlickVideoPlayer>
+    with WidgetsBindingObserver {
   late FlickManager flickManager;
   bool _isFullscreen = false;
   OverlayEntry? _overlayEntry;
@@ -95,7 +96,8 @@ class _FlickVideoPlayerState extends State<FlickVideoPlayer> with WidgetsBinding
     }
 
     if (kIsWeb) {
-      document.documentElement?.onFullscreenChange.listen(_webFullscreenListener);
+      document.documentElement?.onFullscreenChange
+          .listen(_webFullscreenListener);
       document.documentElement?.onKeyDown.listen(_webKeyListener);
     }
 
@@ -126,7 +128,8 @@ class _FlickVideoPlayerState extends State<FlickVideoPlayer> with WidgetsBinding
   void listener() async {
     if (flickManager.flickControlManager!.isFullscreen && !_isFullscreen) {
       _switchToFullscreen();
-    } else if (_isFullscreen && !flickManager.flickControlManager!.isFullscreen) {
+    } else if (_isFullscreen &&
+        !flickManager.flickControlManager!.isFullscreen) {
       _exitFullscreen();
     }
   }
@@ -153,7 +156,8 @@ class _FlickVideoPlayerState extends State<FlickVideoPlayer> with WidgetsBinding
         return Scaffold(
           body: FlickManagerBuilder(
             flickManager: flickManager,
-            child: widget.flickVideoWithControlsFullscreen ?? widget.flickVideoWithControls,
+            child: widget.flickVideoWithControlsFullscreen ??
+                widget.flickVideoWithControls,
           ),
         );
       });
@@ -189,9 +193,11 @@ class _FlickVideoPlayerState extends State<FlickVideoPlayer> with WidgetsBinding
 
   _setPreferredOrientation() {
     // when aspect ratio is less than 1 , video will be played in portrait mode and orientation will not be changed.
-    var aspectRatio = widget.flickManager.flickVideoManager!.videoPlayerValue!.aspectRatio;
+    var aspectRatio =
+        widget.flickManager.flickVideoManager!.videoPlayerValue!.aspectRatio;
     if (_isFullscreen && aspectRatio >= 1) {
-      SystemChrome.setPreferredOrientations(widget.preferredDeviceOrientationFullscreen);
+      SystemChrome.setPreferredOrientations(
+          widget.preferredDeviceOrientationFullscreen);
     } else {
       SystemChrome.setPreferredOrientations(widget.preferredDeviceOrientation);
     }
@@ -199,9 +205,11 @@ class _FlickVideoPlayerState extends State<FlickVideoPlayer> with WidgetsBinding
 
   _setSystemUIOverlays() {
     if (_isFullscreen) {
-      SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: widget.systemUIOverlayFullscreen);
+      SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
+          overlays: widget.systemUIOverlayFullscreen);
     } else {
-      SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: widget.systemUIOverlay);
+      SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
+          overlays: widget.systemUIOverlay);
     }
   }
 
@@ -209,7 +217,8 @@ class _FlickVideoPlayerState extends State<FlickVideoPlayer> with WidgetsBinding
     final isFullscreen = (window.screenTop == 0 && window.screenY == 0);
     if (isFullscreen && !flickManager.flickControlManager!.isFullscreen) {
       flickManager.flickControlManager!.enterFullscreen();
-    } else if (!isFullscreen && flickManager.flickControlManager!.isFullscreen) {
+    } else if (!isFullscreen &&
+        flickManager.flickControlManager!.isFullscreen) {
       flickManager.flickControlManager!.exitFullscreen();
     }
   }


### PR DESCRIPTION
This PR adds the `overlay` parameter to `FlickVideoPlayer` so you can provide an `OverlayState` that will be used to show the fullscreen player.

This resolves the issue where the fullscreen player only covers a portion of the screen if you are using nested navigators for example.

```dart
FlickVideoPlayer(
  flickManager: _manager!,
  overlay: Navigator.of(context, rootNavigator: true).overlay,
),
```

### Small
![Simulator Screenshot - iPhone 15 Pro - 2024-07-12 at 14 44 58](https://github.com/user-attachments/assets/c715bbd1-786c-4902-9ff4-9329abb295ae)

### Fullscreen without passing overlay
The bottom navigation remains visible
![Simulator Screenshot - iPhone 15 Pro - 2024-07-12 at 14 45 38](https://github.com/user-attachments/assets/426bec80-a8bd-4707-812d-7e2a04788740)

###  Fullscreen with passing overlay
![Simulator Screenshot - iPhone 15 Pro - 2024-07-12 at 14 45 18](https://github.com/user-attachments/assets/8b7a6aba-3919-49b8-86d1-ad650cd81392)

